### PR TITLE
Added deploy_wait_time support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ jobs:
                 client_id: ${{ secrets.CONSUMER_KEY_TI01 }}
                 username: ${{ secrets.USERNAME_TI01 }}
                 checkonly: false
+                deploy_wait_time: '10'
                 manifest_path: manifest/package-01.xml,manifest/package-02.xml,manifest/package-03.xml
                 destructive_path: destructive
                 data_factory: scripts/apex/CreateBaseData.apex
@@ -74,6 +75,7 @@ jobs:
 | `checkonly`           | _required_  | Boolean value to indicate whether this action should execute the deploy or only check it, default is false, but if true it will add -c parameter on the force:mdapi:deploy commands |
 | `manifest_path`       | _required_  | Path on the current repository to one or more package.xml that represents the packages to be deployed. Based on this files the metadata package will be created and deployed in the order specified. Ex:  | manifest/package-01.xml,manifest/package-02.xml,manifest/package-03.xml
 | `deploy_testlevel`    | _optional_  | TestLevel applied on the deploy. Default is `RunLocalTests`. If specified `RunSpecifiedTests`, the action will execute only the classes mentioned in the manifest file that contains `@isTest` tag |
+| `deploy_wait_time`    | _optional_  | Wait time for deployment to finish in minutes. Default is `60` |
 | `destructive_path`    | _optional_  | Path on the repo where the destructive changes directory is - if not informed, it's not executed |
 | `data_factory`        | _optional_  | Path on the repo where an APEX script used as a data factory is stored. if not informed, it's not executed |
 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
 
     deploy_wait_time:
         description: 'Wait time for deployment to finish in minutes. Default is 60'
-        required: true
+        required: false
         default: '60'
 
     destructive_path:

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
         required: true
         default: RunLocalTests
 
+    deploy_wait_time:
+        description: 'Wait time for deployment to finish in minutes. Default is 60'
+        required: true
+        default: '60'
+
     destructive_path:
         description: 'Path for the destructive changes directory'
         required: false

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ try {
   deploy.dataFactory = core.getInput('data_factory');
   deploy.checkonly = (core.getInput('checkonly') === 'true' )? true : false;
   deploy.testlevel = core.getInput('deploy_testlevel');
+  deploy.deployWaitTime = core.getInput('deploy_wait_time') || '60'; // Default wait time is 60 minutes
   
   //Login to Org
   sfdx.login(cert,login);

--- a/src/utils/sfdx.js
+++ b/src/utils/sfdx.js
@@ -61,7 +61,7 @@ let deploy = function (deploy){
     for(var i = 0; i < manifestsArray.length; i++){
         manifestTmp = manifestsArray[i];
 
-        var argsDeploy = ['force:source:deploy', '--wait', '10', '--manifest', manifestTmp, '--targetusername', 'sfdc', '--json'];
+        var argsDeploy = ['force:source:deploy', '--wait', deploy.deployWaitTime, '--manifest', manifestTmp, '--targetusername', 'sfdc', '--json'];
 
         if(deploy.checkonly){
             core.info("===== CHECH ONLY ====");
@@ -96,7 +96,7 @@ let destructiveDeploy = function (deploy){
     core.info("=== destructiveDeploy ===");
     if (deploy.destructivePath !== null && deploy.destructivePath !== '') {
         core.info('=== Applying destructive changes ===')
-        var argsDestructive = ['force:mdapi:deploy', '-d', deploy.destructivePath, '-u', 'sfdc', '--wait', '10', '-g', '--json'];
+        var argsDestructive = ['force:mdapi:deploy', '-d', deploy.destructivePath, '-u', 'sfdc', '--wait', deploy.deployWaitTime, '-g', '--json'];
         if (deploy.checkonly) {
             argsDestructive.push('--checkonly');
         }


### PR DESCRIPTION
Added parameter support to get rid of hard-coded 10 minute time limit. Bigger Salesforce instances can take more than 1 hour to perform deployment.